### PR TITLE
chore: add new ghc version (do not merge yet 2026-06-09)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780979320,
-        "narHash": "sha256-GGdkyUw4drXmBRq8+vPjdVWud91IN/4uckxsMKKo3dI=",
+        "lastModified": 1781048285,
+        "narHash": "sha256-w0m2DnFjFe35WcFRIaW/laEMZywCWhrOL/mn8iZxh0g=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "8fecf770a0d98bace83448ab4afd48bf2a9698ed",
+        "rev": "6e2dd52d93bd3fb08dc4191dc188280b8a5cfd0e",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780815147,
-        "narHash": "sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g=",
+        "lastModified": 1780773863,
+        "narHash": "sha256-t0AXyb11HJHwyRkCed8y15unmgwVlbgcIEVdV1XxYvA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
+        "rev": "20872773637de0b44f7ac04cde2098db1286e6d5",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776127325,
-        "narHash": "sha256-0K6I/yPqeIXloD/RtesnyzrZ6ObTxZqcBXq+v2+w2T8=",
+        "lastModified": 1780979320,
+        "narHash": "sha256-GGdkyUw4drXmBRq8+vPjdVWud91IN/4uckxsMKKo3dI=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "2c0f359c5b8aee71dcb27274895e7547889c4be7",
+        "rev": "8fecf770a0d98bace83448ab4afd48bf2a9698ed",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775994940,
-        "narHash": "sha256-z5tkSIdPUs6IG3I9HD2e2stdzOKKh0qDeKkOURYQw6o=",
+        "lastModified": 1780815147,
+        "narHash": "sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d600cdba342cea3b59aef50e093a547a0f4012f",
+        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,8 @@
         "ghc98"
         "ghc910"
         "ghc912"
+        "ghc914"
       ];
-      defaultCompiler = "ghc910";
+      defaultCompiler = "ghc914";
     };
 }

--- a/unliftio-servant-server.cabal
+++ b/unliftio-servant-server.cabal
@@ -28,6 +28,7 @@ tested-with:
    || ==9.8.4
    || ==9.10.3
    || ==9.12.2
+   || ==9.14.1
 
 source-repository head
   type:     git
@@ -44,7 +45,7 @@ library
     -fprint-expanded-synonyms -fwarn-unused-do-bind
 
   build-depends:
-    , base            >=4.14    && <4.22
+    , base            >=4.14    && <4.23
     , mtl             >=2.2.2   && <2.4
     , servant         >=0.19    && <0.21
     , servant-server  >=0.19    && <0.21


### PR DESCRIPTION
Needs `bellroy-nix-foss` to update so we can point to its `master` branch as we do currently (this PR points to a branch on `bellroy-nix-foss` that enables ghc 9.14 support)

TODO:
- [x] https://github.com/bellroy/bellroy-nix-foss/pull/30
- [ ] Wait for servant to revise their `base` bounds
- [ ] Revise hackage metadata if no code change was required